### PR TITLE
Provide a wrapper for hydra's ConfigStore

### DIFF
--- a/kit/hydra.py
+++ b/kit/hydra.py
@@ -12,7 +12,14 @@ from hydra.core.hydra_config import HydraConfig
 from hydra.utils import instantiate
 from omegaconf import DictConfig, OmegaConf
 
-__all__ = ["flatten_dict", "as_pretty_dict", "reconstruct_cmd", "recursively_instantiate"]
+__all__ = [
+    "GroupRegistration",
+    "SchemaRegistration",
+    "flatten_dict",
+    "as_pretty_dict",
+    "reconstruct_cmd",
+    "recursively_instantiate",
+]
 
 
 def flatten_dict(d: MutableMapping, parent_key: str = "", sep: str = ".") -> dict:
@@ -62,7 +69,17 @@ def recursively_instantiate(
 
 
 class SchemaRegistration:
-    """Register hydra schemas."""
+    """Register hydra schemas.
+
+    Example:
+        >>> sr = SchemaRegistration()
+        >>> sr.register(Config, path="experiment_schema")
+        >>> sr.register(TrainerConf, path="trainer/trainer_schema")
+        >>>
+        >>> with sr.new_group("schema/data", target_path="data") as group:
+        >>>    group.add_option(CelebaDataConf, name="celeba")
+        >>>    group.add_option(WaterbirdsDataConf, name="waterbirds")
+    """
 
     def __init__(self) -> None:
         self._cs = ConfigStore.instance()
@@ -79,8 +96,7 @@ class SchemaRegistration:
     @contextmanager
     def new_group(self, group_name: str, *, target_path: str) -> Iterator[GroupRegistration]:
         package = target_path.replace("/", ".")
-        group_reg = GroupRegistration(self._cs, group_name=group_name, package=package)
-        yield group_reg
+        yield GroupRegistration(self._cs, group_name=group_name, package=package)
 
 
 class GroupRegistration:

--- a/kit/hydra.py
+++ b/kit/hydra.py
@@ -4,9 +4,11 @@ from collections.abc import MutableMapping
 from dataclasses import asdict
 from enum import Enum
 import shlex
-from typing import Any, Sequence
+from typing import Any, Iterator, Sequence
+from contextlib import contextmanager
 
 from hydra.core.hydra_config import HydraConfig
+from hydra.core.config_store import ConfigStore
 from hydra.utils import instantiate
 from omegaconf import DictConfig, OmegaConf
 
@@ -57,3 +59,37 @@ def recursively_instantiate(
         for k, v in hydra_config.items()
         if k not in ("_target_",) + tuple(keys_to_exclude)
     }
+
+
+class SchemaRegistration:
+    """Register hydra schemas."""
+
+    def __init__(self) -> None:
+        self._cs = ConfigStore.instance()
+
+    def register(self, config_class: type, *, path: str) -> None:
+        if "." in path:
+            raise ValueError(f"Separate path with '/' and not '.': {path}")
+
+        parts = path.split("/")
+        name = parts[-1]
+        package = ".".join(parts[:-1])
+        self._cs.store(name=name, node=config_class, package=package)
+
+    @contextmanager
+    def new_group(self, group_name: str, *, target_path: str) -> Iterator[GroupRegistration]:
+        package = target_path.replace("/", ".")
+        group_reg = GroupRegistration(self._cs, group_name=group_name, package=package)
+        yield group_reg
+
+
+class GroupRegistration:
+    """Helper for registering a group in hydra."""
+
+    def __init__(self, cs: ConfigStore, group_name: str, package: str):
+        self._cs = cs
+        self._group_name = group_name
+        self._package = package
+
+    def add_option(self, config_class: type, *, name: str) -> None:
+        self._cs.store(group=self._group_name, name=name, node=config_class, package=self._package)

--- a/kit/hydra.py
+++ b/kit/hydra.py
@@ -1,14 +1,14 @@
 """Functions for dealing with hydra."""
 from __future__ import annotations
 from collections.abc import MutableMapping
+from contextlib import contextmanager
 from dataclasses import asdict
 from enum import Enum
 import shlex
 from typing import Any, Iterator, Sequence
-from contextlib import contextmanager
 
-from hydra.core.hydra_config import HydraConfig
 from hydra.core.config_store import ConfigStore
+from hydra.core.hydra_config import HydraConfig
 from hydra.utils import instantiate
 from omegaconf import DictConfig, OmegaConf
 


### PR DESCRIPTION
Intended usage:

```python
sr = SchemaRegistration()
sr.register(Config, path="experiment_schema")
sr.register(TrainerConf, path="trainer/trainer_schema")

with sr.new_group("schema/data", target_path="data") as group:
    group.add_option(CelebaDataConf, name="celeba")
    group.add_option(WaterbirdsDataConf, name="waterbirds")
```