### PR TITLE
Add drop_last attribute to infinite batch samplers.

### DIFF
--- a/kit/torch/utils.py
+++ b/kit/torch/utils.py
@@ -2,7 +2,6 @@ from __future__ import annotations
 from collections.abc import Iterable, Iterator
 from datetime import datetime
 import random
-import time
 from typing import Any, TypeVar
 
 import numpy as np


### PR DESCRIPTION
This PR was motivated by the fact that PL's deepspeed plugin expects the batch_sampler to have drop_last defined for some reason.